### PR TITLE
2024_07_15

### DIFF
--- a/app.R
+++ b/app.R
@@ -4129,7 +4129,7 @@ ui <- shinyUI(semanticPage(
       <br><br> 
       To get and idea of connectivity for each restored pixel combination’s landscape, we measure the movement cost of serval paths across the landscape and take an average 
       of the cost of those paths as an indication of the resistance of that landscape – mean path resistance. These resistance paths are measured between all “nodes” (or clusters)
-      of either contiguous araes of natural habitat, or areas of conservation concern (depending on the focus of the analysis) that occur in the landscape.
+      of either contiguous areas of natural habitat, or areas of conservation concern (depending on the focus of the analysis) that occur in the landscape.
       <br><br> 
       The mean path resistance for each restored landscape is then subtracted from the mean path resistance of the degraded landscape 
       – to get a measure of how much resistance was reduced (or connectivity increased) by each restoration combination. Positive values = reduced resistance and better movement in a landscape,


### PR DESCRIPTION
Changed parallel processor workers from 3 down to 2 in metrics calculations for memory usage stability on the server. Testing so far has demonstrated this works.

Replaced super-assignment to the global environment (<<-) with reactive values where present in the script to prevent conflicts between different server instances.

Corrected typo on line 4118.

Renamed R script file to 'app.R', otherwise running deployApp() throws: 
**Error in `quartoInspect()`: ! Failed to run `quarto inspect` against your content:
ERROR:**
**C:/**[The local file path]**/Restoration_Prioritization_2024-07-05.R is not a valid
Fourth input document**

See: https://forum.posit.co/t/issue-deploy-app-error-in-quartoinspect-failed-to-run-quarto-inspect-against-your-content/185812